### PR TITLE
fix: Add get instance note

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vrchat-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "VRChat MCP Server - Access VRChat API through Model Context Protocol",
   "type": "module",
   "main": "dist/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ const vrchatClient = new VRChatClient({
 
 const server = new McpServer({
   name: 'vrchat-mcp',
-  version: '0.8.0'
+  version: '0.8.1'
 })
 
 createUsersTools(server, vrchatClient)

--- a/src/tools/instances.ts
+++ b/src/tools/instances.ts
@@ -7,7 +7,7 @@ export const createInstancesTools = (server: McpServer, vrchatClient: VRChatClie
     // Name
     'vrchat_get_instance',
     // Description
-    'Get information about a specific instance.',
+    'Get information about a specific instance. Note: Detailed information about instance members is only available if you are the instance owner.',
     {
       worldId: z.string().describe('Must be a valid world ID.'),
       instanceId: z.string().describe('Must be a valid instance ID.'),


### PR DESCRIPTION
This pull request includes updates to the version number and an enhancement to the instance information description. The most important changes are as follows:

Version updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.8.0` to `0.8.1`.
* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL24-R24): Updated the version from `0.8.0` to `0.8.1` in the `McpServer` initialization.

Enhancements:
* [`src/tools/instances.ts`](diffhunk://#diff-7505e1ad54fdcf9aa98d489b17cb37f6b3c3bc4997d05adc7038c249a3773517L10-R10): Enhanced the description of the `vrchat_get_instance` tool to indicate that detailed information about instance members is only available if you are the instance owner.

ref: https://github.com/sawa-zen/vrchat-mcp/issues/10