### PR TITLE
fix: remove import package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vrchat-mcp",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "VRChat MCP Server - Access VRChat API through Model Context Protocol",
   "type": "module",
   "main": "dist/main.js",

--- a/src/VRChatClient.ts
+++ b/src/VRChatClient.ts
@@ -22,7 +22,7 @@ export class VRChatClient {
   notificationsApi: NotificationsApi
   constructor({ username, password, potpSecret, email }: Arguments) {
     this._axiosConfiguration = axios.create({
-      headers: { 'User-Agent': `vrc-mcp/${pkg.version} ${email}` },
+      headers: { 'User-Agent': `vrc-mcp/0.14.1 ${email}` },
     })
     this._vrchatConfiguration = new Configuration({ username, password })
     this._totpSecret = potpSecret

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import dotenv from 'dotenv'
-import pkg from '../package.json' assert { type: 'json' }
 import { VRChatClient } from './VRChatClient.js'
 import { createFriendsTools } from './tools/friends.js'
 import { createUsersTools } from './tools/users.js'
@@ -24,7 +23,7 @@ const vrchatClient = new VRChatClient({
 
 const server = new McpServer({
   name: 'vrchat-mcp',
-  version: pkg.version
+  version: '0.14.1',
 })
 
 createUsersTools(server, vrchatClient)


### PR DESCRIPTION
This pull request includes a version bump to `0.14.1` and updates related to how the version is referenced in the codebase. It also removes an unused import from `src/main.ts`.

### Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.14.0` to `0.14.1`.
* [`src/VRChatClient.ts`](diffhunk://#diff-ef6c713319add7aafbe42f59a330c29d3efbbf1d4bc1211c7d0044e5132191ecL25-R25): Replaced the dynamic version reference in the `User-Agent` header with the hardcoded value `0.14.1`.
* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL27-R26): Updated the `version` property in the `McpServer` initialization to use the hardcoded value `0.14.1` instead of dynamically referencing `pkg.version`.

### Code cleanup:

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL5): Removed the unused import of `pkg` from `package.json`.